### PR TITLE
Add /dh get command and change head tab completion

### DIFF
--- a/src/main/java/me/rayzr522/decoheads/command/CommandDecoHeadsAdmin.java
+++ b/src/main/java/me/rayzr522/decoheads/command/CommandDecoHeadsAdmin.java
@@ -54,7 +54,7 @@ public class CommandDecoHeadsAdmin implements CommandExecutor, TabCompleter {
             if (args[0].equalsIgnoreCase("remove") || args[0].equalsIgnoreCase("disable") || args[0].equalsIgnoreCase("enable")) {
                 String filter = ArrayUtils.concat(Arrays.copyOfRange(args, 1, args.length), " ");
                 return plugin.getHeadManager().getHeads().stream()
-                        .filter(head -> head.getName().toLowerCase().startsWith(filter.toLowerCase()))
+                        .filter(head -> head.getInternalName().toLowerCase().startsWith(filter.toLowerCase()))
                         .map(Head::getName)
                         .collect(Collectors.toList());
             }

--- a/src/main/java/me/rayzr522/decoheads/command/CommandDecoHeadsAdmin.java
+++ b/src/main/java/me/rayzr522/decoheads/command/CommandDecoHeadsAdmin.java
@@ -55,7 +55,7 @@ public class CommandDecoHeadsAdmin implements CommandExecutor, TabCompleter {
                 String filter = ArrayUtils.concat(Arrays.copyOfRange(args, 1, args.length), " ");
                 return plugin.getHeadManager().getHeads().stream()
                         .filter(head -> head.getInternalName().toLowerCase().startsWith(filter.toLowerCase()))
-                        .map(Head::getName)
+                        .map(Head::getInternalName)
                         .collect(Collectors.toList());
             }
         }
@@ -221,7 +221,7 @@ public class CommandDecoHeadsAdmin implements CommandExecutor, TabCompleter {
                 head.setEnabled(false);
                 headManager.save();
 
-                player.sendMessage(plugin.tr("command.decoheadsadmin.disable.disabled", name));
+                player.sendMessage(plugin.tr("command.decoheadsadmin.disable.disabled", head.getName()));
                 break;
             }
             case "enable": {
@@ -248,7 +248,7 @@ public class CommandDecoHeadsAdmin implements CommandExecutor, TabCompleter {
                 head.setEnabled(true);
                 headManager.save();
 
-                player.sendMessage(plugin.tr("command.decoheadsadmin.enable.enabled", name));
+                player.sendMessage(plugin.tr("command.decoheadsadmin.enable.enabled", head.getName()));
                 break;
             }
             default:

--- a/src/main/java/me/rayzr522/decoheads/data/Head.java
+++ b/src/main/java/me/rayzr522/decoheads/data/Head.java
@@ -116,7 +116,7 @@ public class Head {
         return isEnabled() && DecoHeads.getInstance().checkPermission(String.format("head.%s", getInternalName()), sender, false);
     }
 
-    private String getInternalName() {
+    public String getInternalName() {
         return name.toLowerCase().replaceAll("[^a-z0-9-]", "-");
     }
 

--- a/src/main/java/me/rayzr522/decoheads/data/HeadManager.java
+++ b/src/main/java/me/rayzr522/decoheads/data/HeadManager.java
@@ -88,11 +88,11 @@ public class HeadManager {
     }
 
     public Optional<Head> findByName(String name) {
-        return getHeads().stream().filter(head -> head.getName().toLowerCase().equals(name.toLowerCase())).findFirst();
+        return getHeads().stream().filter(head -> head.getInternalName().toLowerCase().equals(name.toLowerCase())).findFirst();
     }
 
     public void addHead(Head head) {
-        if (findByName(head.getName()).isPresent()) {
+        if (findByName(head.getInternalName()).isPresent()) {
             throw new IllegalArgumentException("The head '" + head.getName() + "' already exists!");
         }
         heads.add(head);

--- a/src/main/java/me/rayzr522/decoheads/util/NamePredicate.java
+++ b/src/main/java/me/rayzr522/decoheads/util/NamePredicate.java
@@ -16,6 +16,6 @@ public class NamePredicate implements Predicate<Head> {
 
     @Override
     public boolean test(Head h) {
-        return h.getName().toLowerCase().contains(filter.toLowerCase());
+        return h.getInternalName().toLowerCase().contains(filter.toLowerCase());
     }
 }

--- a/src/main/resources/heads.yml
+++ b/src/main/resources/heads.yml
@@ -1006,15 +1006,15 @@ heads:
       cost: -1.0
       texture: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYmQ4OThjNDBlNDdjNWQyZDc2OTI0MDY1MzYwNzY4MDY1ZDYyNGVlNWI5ZWUwYmU5ZTEyYjk4ZmI3N2M3NiJ9fX0=
       uuid: 2f380f4a-64c3-4b2c-af18-6c491692e649
-    Ä:
+    A Umlaut:
       cost: -1.0
       texture: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNGM5YzJiYmQ3YjdmNzIwNGRjZWI1NzI5YTZmYmE3ZmQ0NWQ2ZjE5M2YzNzYwZWM1OWE2ODA3NTMzZTYzYiJ9fX0=
       uuid: 8a2ecdf9-9be0-4dac-90b5-560587de6772
-    Ü:
+    U Umlaut:
       cost: -1.0
       texture: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvY2FlYzUzZTRhNmQyMjFhZmQ3Mjk3YjY1ZTU1YmU4NzkxM2NmOWNiN2Y0ZjQ1NDdmNzE4NjEyMDcwMWQ4ZCJ9fX0=
       uuid: 6961d9d9-e0f8-49f8-9d25-d099a1830efe
-    Ö:
+    O Umlaut:
       cost: -1.0
       texture: eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYzgzZDQyYmNiOWI4ZTY2YzE2MTY2Y2NmMjYxZTJmOWY3OGM2OGVlNzg4NmRhMjI1ZTQzODk1Y2RiY2FmNWYifX19
       uuid: 57d010fb-824f-4ab2-b34e-ba24535a94ea

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -22,6 +22,11 @@ command:
             no-username: "&cYou must specify a username!"
             given: "Gave you the head of '{0}'"
             given-cost: "Gave you the head of '{0}' for {1}"
+        give:
+            usage: "Usage: &7/decoheads give <head> [player]"
+            invalid-player: "&cThe player '{0}' is not online!"
+            invalid-head: "&cThe head '{0}' does not exist!"
+            given: "Gave '{0}' the head '{1}'"
     decoheadsadmin:
         usage: "Usage: &7/decoheadsadmin reload|settings|editor|add|remove|disable"
         reloaded: "&eConfig & settings reloaded"


### PR DESCRIPTION
closes #35 

additionally, this rewrites internally how tab completion and commands reference heads by using the internal name rather than the display name. this makes tab-completion significantly easier to implement, as it doesn't require spaces, and also makes positional arguments far less clumsy.

one problem with this is that it does mean any heads with the same internal name are now impossible to differentiate in commands that involve searching for those heads. this can be easily addressed by making those names include unique alphanumeric characters. the main ones that I changed in this were changing heads with a letter and an umlaut to actually be `<letter> Umluat` in the heads.yaml, for example `A Umlaut`, making it possible to reference it as `a-umlaut` in commands (rather than just the not-so-optimal `-`)

I'll have to make sure to mention this in the release notes, along with the new messages that have been added